### PR TITLE
fix(course): reverse school year order

### DIFF
--- a/components/NavbarYears.tsx
+++ b/components/NavbarYears.tsx
@@ -14,7 +14,6 @@ export default function NavbarYears({ currentYear }: { currentYear: number }) {
     return (
       <div className='gap-x-4 flex flex-row overflow-scroll py-1 border-b bg-white bg-opacity-60 backdrop-blur-md w-full px-6 lg:px-20'>
         {COURSE_YEARS.slice()
-          .reverse()
           .map(year =>
             year === currentYear ? (
               <div key={year} className='font-semibold text-slate-800'>


### PR DESCRIPTION
Most recent school year is on the right. Makes more sense since we read left to right. Picture below:
<img width="671" alt="Screenshot 2023-05-12 at 12 20 20 PM" src="https://github.com/jinh0/cloudberry/assets/99054048/e669bbf1-6fc2-41a9-81ff-335b780d420a">

Old version:
<img width="654" alt="Screenshot 2023-05-12 at 12 20 49 PM" src="https://github.com/jinh0/cloudberry/assets/99054048/74557dcf-1717-411f-94d2-29844556f0d5">